### PR TITLE
BUG FIX: Tourney title writing & New data mined

### DIFF
--- a/codagent/all_data.csv
+++ b/codagent/all_data.csv
@@ -1698,3 +1698,103 @@ Date,Time,Title,Buy-in Per Player,Platforms,Team Size,Tournament Type (Ex: Singl
 "February 22, 2023",10:27 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
 "February 22, 2023",4:35 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
 "February 22, 2023",4:22 AM,3v3 $100 GTD CONSOLE SND,$10,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 3,$99
+"March 25, 2023",7:00 AM,4v4 $1814 Prestige Switcheroo,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 3,$1800
+"March 25, 2023",6:20 AM,1v1 1ND *SCAR ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$9
+"March 25, 2023",6:15 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 25, 2023",5:20 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$4
+"March 25, 2023",3:25 AM,2v2 $50 GTD 1ND *FORTRESS ONLY* SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"March 25, 2023",2:25 AM,3v3 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$21
+"March 25, 2023",1:25 AM,4v4 *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,4,Best of 1,$12
+"March 24, 2023",11:20 PM,4v4 $75 FREE ENTRY @LowtierCircuit VARIANT | MUST FOLLOW @LOWTIERCIRCUIT,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,19,Best of 3,$76
+"March 24, 2023",7:00 AM,3v3 Switch $675,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$675
+"March 24, 2023",6:20 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$9
+"March 24, 2023",5:20 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$6
+"March 24, 2023",2:22 AM,2v2 *NO MASTERS* MWII SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$28
+"March 24, 2023",12:23 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"March 23, 2023",11:22 PM,4v4 HARDPOINT,$4,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,5,Best of 3,$56
+"March 23, 2023",10:21 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$10
+"March 23, 2023",5:50 AM,1v1 1ND *FORTRESS ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 23, 2023",3:56 AM,3v3 $75 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$75
+"March 23, 2023",1:57 AM,4v4 *NO MARCH WINNERS* VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,3,Best of 3,$52
+"March 22, 2023",9:20 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$15
+"March 22, 2023",6:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 22, 2023",5:25 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$12
+"March 22, 2023",3:53 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"March 22, 2023",12:23 AM,2v2 *NO MASTERS* MWII SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$26
+"March 21, 2023",11:22 PM,4v4 HARDPOINT,$4,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,4,Best of 3,$44
+"March 21, 2023",10:10 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,9,Best of 1,$10
+"March 21, 2023",8:25 PM,2v2 AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$22
+"March 21, 2023",6:20 AM,1v1 1ND *SCAR ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$10
+"March 21, 2023",4:50 AM,2v2 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$28
+"March 21, 2023",3:55 AM,3v3 1ND *NO MASTERS* SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$54
+"March 21, 2023",2:51 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$8
+"March 21, 2023",1:52 AM,3v3 $75 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$75
+"March 21, 2023",12:55 AM,1v1 $12 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$12
+"March 21, 2023",12:50 AM,2v2 *NO MASTERS* MWII SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$58
+"March 20, 2023",11:55 PM,3v3 $600 $BOZE MONDAY PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,26,Best of 3,$510
+"March 20, 2023",10:25 PM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"March 20, 2023",9:20 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,6,Best of 1,$15
+"March 20, 2023",7:00 AM,3v3 $378 Switcheroo,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$348
+"March 20, 2023",7:00 AM,4v4 CXP Switcheroo $406,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 3,$404
+"March 20, 2023",6:45 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 20, 2023",6:20 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$6
+"March 20, 2023",4:20 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$12
+"March 20, 2023",3:25 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"March 20, 2023",2:22 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$6
+"March 19, 2023",10:25 PM,4v4 DOUBLE ELIMINATION HARDPOINT,$5,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,2,Best of 3,$36
+"March 19, 2023",9:15 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,11,Best of 1,$15
+"March 19, 2023",7:00 AM,3v3 MWII SND Switcheroo $2850,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$2850
+"March 19, 2023",6:27 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$6
+"March 19, 2023",5:20 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$10
+"March 19, 2023",4:25 AM,3v3 $75 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$75
+"March 19, 2023",1:30 AM,4v4 *NO MARCH WINNERS* VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,4,Best of 3,$68
+"March 19, 2023",12:55 AM,1v1 $20 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$20
+"March 18, 2023",11:30 PM,2v2 $50 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"March 18, 2023",10:30 PM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$8
+"March 18, 2023",9:00 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,6,Best of 1,$15
+"March 18, 2023",3:21 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$4
+"March 18, 2023",12:22 AM,4v4 ELECTRIFYSTEEL x CODAGENT HARDPOINT,$4,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,6,Best of 3,$68
+"March 17, 2023",7:00 AM,$430 3v3 switcheroo,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 3,$429
+"March 17, 2023",6:20 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$11
+"March 17, 2023",6:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$11
+"March 17, 2023",5:50 AM,2v2 1ND AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$14
+"March 17, 2023",5:25 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$12
+"March 17, 2023",5:20 AM,2v2 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$14
+"March 17, 2023",1:22 AM,2v2 *NO MASTERS* MWII SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$30
+"March 16, 2023",10:21 PM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$4
+"March 16, 2023",9:15 PM,3v3 $15 FE 1ND HIMMELMATT EXPO SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,12,Best of 1,$15
+"March 16, 2023",7:00 AM,3v3 $1424 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$1200
+"March 16, 2023",6:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 16, 2023",6:20 AM,2v2 1ND AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$14
+"March 16, 2023",3:45 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$6
+"March 16, 2023",1:50 AM,2v2 *NO MASTERS* MWII SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$28
+"March 15, 2023",11:27 PM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"March 15, 2023",10:35 PM,3v3 $75 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$75
+"March 15, 2023",9:22 PM,3v3 $15 FE HIMMELMATT EXPO ONLY SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,7,Best of 1,$15
+"March 15, 2023",8:28 PM,1v1 $20 GTD CONSOLE SND,$6,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 3,$12
+"March 15, 2023",7:00 AM,4v4 $1080 Switcheroo,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 1,$1080
+"March 15, 2023",6:28 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$6
+"March 15, 2023",6:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 15, 2023",5:20 AM,2v2 $50 GTD 1ND *FORTRESS ONLY* SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"March 15, 2023",4:20 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$72
+"March 15, 2023",2:22 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$6
+"March 14, 2023",11:20 PM,3v3 *DOLLAR ENTRY* 1ND NOV/AM SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 1,$6
+"March 14, 2023",10:20 PM,2v2 $50 GTD AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"March 14, 2023",8:24 PM,1v1 $20 GTD CONSOLE SND,$6,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 3,$12
+"March 14, 2023",8:20 PM,2v2 *VAZNEV ONLY* SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$18
+"March 14, 2023",7:00 AM,3v3 $1698 switcheroo,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 3,$1299
+"March 14, 2023",3:20 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$4
+"March 14, 2023",2:00 AM,3v3 $128,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$138
+"March 14, 2023",12:52 AM,4v4 *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,3,Best of 1,$8
+"March 13, 2023",11:55 PM,2v2 $500 $BOZE MONDAY CONSOLE PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,27,Best of 3,$400
+"March 13, 2023",9:15 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,9,Best of 1,$10
+"March 13, 2023",8:25 PM,1v1 $20 GTD CONSOLE SND,$6,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 3,$20
+"March 13, 2023",8:21 PM,2v2 AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$22
+"March 13, 2023",7:00 AM,3v3 $363 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$363
+"March 13, 2023",4:50 AM,3v3 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 1,$27
+"March 13, 2023",3:50 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,0,Best of 1,$4
+"March 13, 2023",1:55 AM,4v4 *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 1,$8
+"March 12, 2023",11:21 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$10
+"March 12, 2023",8:00 AM,3v3 $108 vg switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$108
+"March 12, 2023",4:50 AM,switch 189,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$189
+"March 12, 2023",3:30 AM,3v3 $75 GTD VANGUARD SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 3,$75

--- a/codagent/all_data.csv
+++ b/codagent/all_data.csv
@@ -1415,3 +1415,103 @@ Date,Time,Title,Buy-in Per Player,Platforms,Team Size,Tournament Type (Ex: Singl
 "February 5, 2023",4:30 AM,2v2 $50 GTD 1ND *VAZNEZ ONLY* SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
 "February 5, 2023",3:00 AM,2v2 $150 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$150
 "February 5, 2023",2:53 AM,4v4 *NO ABEZYS* *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,9,Best of 1,$28
+"February 15, 2023",11:28 PM,3v3 $60 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$60
+"February 15, 2023",9:28 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 15, 2023",8:15 PM,2v2 $20 FE 1ND ASHIKA ISLAND KILL RACE,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$20
+"February 15, 2023",7:00 PM,1v1 *SCAR ONLY* 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$12
+"February 15, 2023",2:50 PM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$9
+"February 15, 2023",1:15 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$10
+"February 15, 2023",11:50 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$4
+"February 15, 2023",11:20 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 15, 2023",8:25 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 15, 2023",8:00 AM,3v3 $450 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$450
+"February 15, 2023",6:25 AM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$40
+"February 15, 2023",6:25 AM,2v2 $50 GTD 1ND AR/SMG SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 15, 2023",5:30 AM,3v3 $90 GTD 1ND *NO SNIPES* SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$90
+"February 15, 2023",4:22 AM,2v2 SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$18
+"February 15, 2023",3:25 AM,4v4 *NO 2023 WINNERS* VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,4,Best of 3,$68
+"February 15, 2023",3:00 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 15, 2023",2:22 AM,2v2 $60 GTD AR/SMG 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$60
+"February 15, 2023",1:59 AM,4v4 ElectrifySteel x CODAgent Double Elim Variant,$4,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,3,Best of 3,$32
+"February 15, 2023",1:52 AM,2v2 $60 GTD CONSOLE SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$60
+"February 15, 2023",1:20 AM,2v2 L♡HVERS DAY COED SND,$7,"['xbox', 'playstation', 'battle.net']",2,double elimination,2v2,9,Best of 3,$112
+"February 15, 2023",12:51 AM,2v2 $50 GTD NOV/AM SND ($4 / PLAYER),$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$50
+"February 15, 2023",12:24 AM,4v4 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 1,$8
+"February 15, 2023",12:00 AM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 14, 2023",11:25 PM,3v3 $60 GTD *NO SNIPES* SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 3,$60
+"February 14, 2023",10:25 PM,1v1 $50 GTD *NO 2023 WINNERS* KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,7,Best of 1,$50
+"February 14, 2023",10:22 PM,2v2 1ND *VAZNEV ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$16
+"February 14, 2023",9:51 PM,1v1 1ND *SHIPMENT ONLY* HP,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$14
+"February 14, 2023",9:10 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,10,Best of 1,$15
+"February 14, 2023",8:25 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 14, 2023",7:55 PM,2v2 CONSOLE AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$24
+"February 14, 2023",7:20 PM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$9
+"February 14, 2023",6:55 PM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,6,Best of 1,$50
+"February 14, 2023",3:20 PM,2v2 $50 GTD *VAZNEV ONLY* SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 14, 2023",2:00 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,9,Best of 1,$10
+"February 14, 2023",12:22 PM,2v2 1ND AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$18
+"February 14, 2023",10:20 AM,2v2 *TWO DOLLAR ENTRY* 1ND SND,$2,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$10
+"February 14, 2023",9:00 AM,3v3 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$27
+"February 14, 2023",8:27 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$10
+"February 14, 2023",8:27 AM,2v2 $40 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$40
+"February 14, 2023",7:50 AM,3v3 1ND *NO PREVIOUS WINNERS* HP,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$30
+"February 14, 2023",7:20 AM,3v3 1ND *NO SNIPES* SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$33
+"February 14, 2023",6:20 AM,2v2 $50 GTD AR/SMG 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 14, 2023",5:20 AM,3v3 $75 GTD 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$75
+"February 14, 2023",4:50 AM,4v4 1ND *DOLLAR ENTRY* MWII HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,8,Best of 1,$28
+"February 14, 2023",4:25 AM,3v3 $100 GTD CONSOLE SND,$10,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 3,$99
+"February 14, 2023",4:22 AM,4v4 $80 GTD 1ND *NO SNIPES* SND,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,5,Best of 1,$84
+"February 14, 2023",3:23 AM,2v2 *VAZNEV ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 3,$34
+"February 14, 2023",2:52 AM,4v4 VARIANT,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 3,$56
+"February 14, 2023",1:55 AM,3v3 $300 PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,25,Best of 3,$300
+"February 14, 2023",1:51 AM,2v2 $60 GTD CONSOLE SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$60
+"February 14, 2023",12:52 AM,2v2 $50 GTD NOV/AM SND ($4 / PLAYER),$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 3,$50
+"February 13, 2023",11:55 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 13, 2023",11:52 PM,3v3 $42 GTD CONSOLE 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 1,$42
+"February 13, 2023",11:15 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,18,Best of 1,$15
+"February 13, 2023",10:52 PM,2v2 $50 GTD 1ND AR/SMG SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$50
+"February 13, 2023",10:23 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 13, 2023",8:56 PM,1v1 $20 GTD CONSOLE SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 3,$20
+"February 13, 2023",8:22 PM,2v2 $112 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,8,Best of 1,$112
+"February 13, 2023",8:20 PM,2v2 AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$36
+"February 13, 2023",7:30 PM,3v3 $42 GTD SND (NA + EU),$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 3,$42
+"February 13, 2023",6:20 PM,1v1 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$10
+"February 13, 2023",4:52 PM,2v2 $50 GTD SND (NA + EU),$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$28
+"February 13, 2023",11:15 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$11
+"February 13, 2023",9:20 AM,2v2 *VAZNEZ ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$28
+"February 13, 2023",8:28 AM,2v2 $40 GTD 1ND AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$40
+"February 13, 2023",8:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$16
+"February 13, 2023",8:00 AM,Switch Prize,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$448
+"February 13, 2023",7:50 AM,2v2 *NO 2023 WINNERS* 1ND SHIPMENT HP,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$28
+"February 13, 2023",6:30 AM,2v2 $50 GTD 1ND AR/SMG SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 13, 2023",5:20 AM,4v4 $80 GTD 1ND *NO SNIPES* SND,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,4,Best of 1,$80
+"February 13, 2023",4:22 AM,2v2 AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$28
+"February 13, 2023",2:57 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 13, 2023",2:52 AM,4v4 *NO 2023 WINNERS* VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,7,Best of 3,$136
+"February 13, 2023",1:40 AM,4v4 $100 FE @TheGrind_GG SND,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,24,Best of 3,$100
+"February 13, 2023",1:00 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 13, 2023",12:52 AM,2v2 $50 GTD NOV/AM SND ($4 / PLAYER),$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 13, 2023",12:21 AM,4v4 *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,4,Best of 1,$12
+"February 12, 2023",11:58 PM,1v1 $50 GTD *NO 2023 WINNERS* KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$50
+"February 12, 2023",11:52 PM,3v3 $42 GTD CONSOLE 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$42
+"February 12, 2023",11:23 PM,2v2 $50 GTD *VAZNEV ONLY* SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 12, 2023",10:56 PM,4v4 DOUBLE ELIM VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,3,Best of 3,$52
+"February 12, 2023",10:30 PM,2v2 $150 GTD NOV/AM BEST OF 3 KILL RACE,$10,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 3,$150
+"February 12, 2023",10:22 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 12, 2023",10:10 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,17,Best of 1,$10
+"February 12, 2023",9:56 PM,3v3 $60 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$60
+"February 12, 2023",9:22 PM,2v2 AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$16
+"February 12, 2023",8:27 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,8,Best of 1,$100
+"February 12, 2023",7:50 PM,2v2 CONSOLE AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$18
+"February 12, 2023",7:20 PM,2v2 $50 GTD SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$50
+"February 12, 2023",6:20 PM,1v1 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$9
+"February 12, 2023",5:27 PM,2v2 *VAZNEV ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$20
+"February 12, 2023",12:15 PM,1v1 1ND *SCAR ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$9
+"February 12, 2023",11:20 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 1,$6
+"February 12, 2023",8:27 AM,2v2 $40 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$40
+"February 12, 2023",8:15 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$12
+"February 12, 2023",7:20 AM,3v3 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$21
+"February 12, 2023",6:55 AM,2v2 $50 GTD 1ND AR/SMG SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$50
+"February 12, 2023",6:20 AM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$24
+"February 12, 2023",3:56 AM,2v2 AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 3,$34
+"February 12, 2023",3:30 AM,4v4 VARIANT,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,3,Best of 3,$44

--- a/codagent/all_data.csv
+++ b/codagent/all_data.csv
@@ -1615,3 +1615,86 @@ Date,Time,Title,Buy-in Per Player,Platforms,Team Size,Tournament Type (Ex: Singl
 "February 16, 2023",5:25 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$15
 "February 16, 2023",9:50 AM,1v1 1ND *SCAR ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
 "February 16, 2023",8:15 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 4, 2023",9:15 PM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$9
+"March 4, 2023",7:30 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,11,Best of 1,$15
+"March 4, 2023",8:00 AM,3v3 $306 switcheroo,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$306
+"March 4, 2023",7:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"March 4, 2023",6:20 AM,2v2 $50 GTD 1ND *FORTRESS ONLY* SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"March 4, 2023",5:00 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"March 3, 2023",11:16 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,8,Best of 1,$10
+"March 3, 2023",9:56 PM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$50
+"March 3, 2023",8:00 AM,$159 bo3 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$159
+"March 3, 2023",7:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$9
+"March 3, 2023",4:58 AM,2v2 $50 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$30
+"March 3, 2023",3:51 AM,3v3 $78 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$78
+"March 3, 2023",2:53 AM,1v1 $50 GTD NOV/AM 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,6,Best of 1,$50
+"March 3, 2023",1:55 AM,4v4 DOUBLE ELIM MWII SND *CDL + GAs*,$6,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,4,Best of 3,$68
+"March 3, 2023",12:26 AM,2v2 $40 GTD SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$40
+"March 2, 2023",10:20 PM,2v2 $50 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"March 2, 2023",9:25 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,7,Best of 1,$15
+"March 2, 2023",5:58 AM,3v3 $50 GTD 1ND *NO SNIPES* SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$48
+"March 2, 2023",4:26 AM,2v2 $60 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$60
+"March 2, 2023",2:58 AM,2v2 $75 GTD NOV/AM SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$74
+"March 2, 2023",1:58 AM,2v2 $60 GTD CONSOLE NOV/AM SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$60
+"March 2, 2023",12:27 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"March 1, 2023",11:00 PM,1v1 $50 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$50
+"March 1, 2023",10:30 PM,3v3 1ND *DOLLAR ENTRY* SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$9
+"March 1, 2023",8:00 AM,4v4 $200 switch,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 1,$200
+"March 1, 2023",7:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$9
+"March 1, 2023",4:55 AM,3v3 $50 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$51
+"March 1, 2023",1:25 AM,4v4 VARIANT,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,3,Best of 3,$56
+"February 28, 2023",11:53 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 28, 2023",11:51 PM,3v3 $45 GTD CONSOLE 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$45
+"February 28, 2023",10:21 PM,2v2 $28 GTD CONSOLE 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$28
+"February 28, 2023",10:15 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,12,Best of 1,$10
+"February 28, 2023",9:25 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 28, 2023",9:22 PM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 28, 2023",8:00 AM,$244 switch,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 3,$244
+"February 28, 2023",7:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$8
+"February 28, 2023",2:25 AM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 28, 2023",1:55 AM,2v2 $60 GTD CONSOLE NOV/AM SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$60
+"February 28, 2023",1:22 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 1,$6
+"February 28, 2023",12:55 AM,1v1 $50 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 28, 2023",12:27 AM,3v3 $Boze Monday $1000 PRESTIGE ONLY SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,22,Best of 3,$900
+"February 27, 2023",11:50 PM,3v3 $45 GTD CONSOLE 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$45
+"February 27, 2023",10:22 PM,2v2 $50 GTD CONSOLE 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 27, 2023",10:15 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,8,Best of 1,$15
+"February 27, 2023",9:25 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 27, 2023",9:20 PM,2v2 $50 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 27, 2023",8:20 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 27, 2023",7:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$8
+"February 27, 2023",5:20 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$6
+"February 27, 2023",2:52 AM,1v1 $50 GTD NOV/AM 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$50
+"February 27, 2023",2:21 AM,2v2 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$4
+"February 27, 2023",1:51 AM,2v2 $60 GTD CONSOLE NOV/AM SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$60
+"February 27, 2023",1:23 AM,2v2 $50 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 27, 2023",12:22 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$6
+"February 26, 2023",9:30 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 26, 2023",9:25 PM,2v2 $30 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$30
+"February 26, 2023",10:47 AM,$819 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$750
+"February 26, 2023",8:50 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$8
+"February 26, 2023",8:00 AM,3v3 switcheroo $613,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$612
+"February 26, 2023",7:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$10
+"February 26, 2023",6:57 AM,3v3 $50 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$48
+"February 26, 2023",5:27 AM,2v2 $50 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 26, 2023",2:23 AM,2v2 $400+ CONSOLE PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,27,Best of 3,$400
+"February 26, 2023",2:03 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 26, 2023",12:30 AM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 26, 2023",12:20 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,6,Best of 1,$15
+"February 25, 2023",10:30 PM,2v2 $50 GTD CONSOLE 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"February 25, 2023",10:10 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,8,Best of 1,$10
+"February 25, 2023",9:29 PM,3v3 $50 GTD *NO SNIPES* 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$48
+"February 25, 2023",6:27 AM,2v2 $50 GTD 1ND *FORTRESS ONLY* SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"February 25, 2023",2:50 AM,1v1 $50 GTD KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,6,Best of 1,$50
+"February 25, 2023",1:25 AM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 25, 2023",12:22 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 25, 2023",12:15 AM,4v4 $100 CXP FREE ENTRY HARDPOINT *MUST BE ON CXP ROSTER*,$0,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,6,Best of 3,$100
+"February 24, 2023",8:00 AM,3v3 $81 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$81
+"February 24, 2023",8:00 AM,3v3 $603 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$603
+"February 24, 2023",2:00 AM,2v2 $250 PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,22,Best of 3,$200
+"February 24, 2023",12:25 AM,3v3 $75 GTD 1ND *NO SNIPES* SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$75
+"February 23, 2023",1:55 AM,2v2 $60 GTD CONSOLE SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$60
+"February 23, 2023",12:57 AM,2v2 $50 GTD NOV/AM SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$50
+"February 22, 2023",10:27 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 22, 2023",4:35 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"February 22, 2023",4:22 AM,3v3 $100 GTD CONSOLE SND,$10,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 3,$99

--- a/codagent/all_data.csv
+++ b/codagent/all_data.csv
@@ -1515,3 +1515,103 @@ Date,Time,Title,Buy-in Per Player,Platforms,Team Size,Tournament Type (Ex: Singl
 "February 12, 2023",6:20 AM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$24
 "February 12, 2023",3:56 AM,2v2 AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 3,$34
 "February 12, 2023",3:30 AM,4v4 VARIANT,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,3,Best of 3,$44
+"February 24, 2023",5:22 PM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 24, 2023",10:52 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 24, 2023",10:22 PM,2v2 $50 GTD AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 24, 2023",3:52 AM,1v1 $50 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 24, 2023",2:00 AM,2v2 $250 PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,24,Best of 3,$200
+"February 24, 2023",1:22 AM,4v4 ElectrifySteel x CODAgent Double Elim Variant,$4,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,3,Best of 3,$32
+"February 24, 2023",12:25 AM,3v3 $75 GTD 1ND *NO SNIPES* SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$75
+"February 23, 2023",9:20 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,8,Best of 1,$15
+"February 23, 2023",9:00 PM,1v1 $20 GTD CONSOLE SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 3,$20
+"February 23, 2023",8:32 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 23, 2023",8:20 AM,2v2 $40 GTD 1ND AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$40
+"February 23, 2023",8:00 AM,$656 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$600
+"February 23, 2023",2:54 AM,1v1 $50 GTD NOV/AM 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,7,Best of 1,$50
+"February 23, 2023",1:55 AM,2v2 $60 GTD CONSOLE SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$60
+"February 23, 2023",12:57 AM,2v2 $50 GTD NOV/AM SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 23, 2023",12:20 AM,4v4 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 1,$8
+"February 22, 2023",11:00 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 22, 2023",10:27 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 22, 2023",9:20 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,6,Best of 1,$15
+"February 22, 2023",8:32 PM,2v2 AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$24
+"February 22, 2023",8:20 AM,2v2 $40 GTD 1ND AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$40
+"February 22, 2023",8:00 AM,$486 switch,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 1,$484
+"February 22, 2023",4:35 AM,2v2 $50 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 22, 2023",4:22 AM,3v3 $100 GTD CONSOLE SND,$10,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 3,$99
+"February 22, 2023",3:20 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 22, 2023",12:52 AM,2v2 $50 GTD NOV/AM SND ($4 / PLAYER),$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 22, 2023",12:30 AM,2v2 $500 PRESTIGE KILL RACE,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,13,Best of 3,$500
+"February 22, 2023",12:21 AM,3v3 $75 GTD 1ND *NO SNIPES* SND,$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$75
+"February 21, 2023",11:51 PM,3v3 $42 GTD CONSOLE 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,1,Best of 1,$42
+"February 21, 2023",11:22 PM,2v2 $30 GTD *DOME ONLY* SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$30
+"February 21, 2023",10:25 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 21, 2023",9:12 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,12,Best of 1,$10
+"February 21, 2023",1:27 PM,2v2 $50 GTD 1ND AR/SMG SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"February 21, 2023",8:27 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 21, 2023",8:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$12
+"February 21, 2023",8:00 AM,$183 switch,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$183
+"February 21, 2023",7:20 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$6
+"February 21, 2023",3:25 AM,3v3 $75 GTD *NO SNIPES* 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$75
+"February 21, 2023",1:53 AM,2v2 $32 GTD CONSOLE SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 3,$32
+"February 21, 2023",1:26 AM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$50
+"February 21, 2023",12:21 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$12
+"February 20, 2023",11:26 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 20, 2023",11:22 PM,2v2 AR/SMG 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$22
+"February 20, 2023",10:20 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$15
+"February 20, 2023",9:56 PM,1v1 $50 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 20, 2023",9:22 PM,2v2 $50 GTD SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 3,$50
+"February 20, 2023",8:25 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 20, 2023",8:20 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,8,Best of 1,$10
+"February 20, 2023",8:50 AM,1v1 1ND *SCAR ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 20, 2023",8:25 AM,2v2 $40 GTD *VAZNEZ ONLY* 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$40
+"February 20, 2023",3:22 AM,2v2 AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 3,$18
+"February 20, 2023",2:56 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 20, 2023",1:22 AM,1v1 $50 GTD KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 19, 2023",11:28 PM,2v2 $100 GTD 1ND *NO FEBRUARY WINNERS* KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$100
+"February 19, 2023",11:16 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,9,Best of 1,$15
+"February 19, 2023",11:00 PM,4v4 NO T32 VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,3,Best of 3,$52
+"February 19, 2023",10:27 PM,2v2 $50 GTD SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 19, 2023",10:20 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 19, 2023",8:57 PM,1v1 $20 GTD CONSOLE SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 3,$20
+"February 19, 2023",8:30 PM,2v2 *VAZNEZ ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,0,Best of 3,$14
+"February 19, 2023",8:27 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 19, 2023",8:10 PM,CXP IN SEASON OPEN #1 *MUST HAVE CXP TEAM PASS*,$0,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,18,Best of 3,$200
+"February 19, 2023",7:30 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$6
+"February 19, 2023",5:30 AM,3v3 $90 GTD 1ND * NO SNIPES* SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$90
+"February 19, 2023",3:00 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 19, 2023",1:32 AM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$50
+"February 18, 2023",11:20 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,8,Best of 1,$15
+"February 18, 2023",10:30 PM,2v2 $50 GTD SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$50
+"February 18, 2023",10:27 PM,2v2 $50 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$50
+"February 18, 2023",9:55 PM,1v1 $50 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,6,Best of 1,$50
+"February 18, 2023",9:25 PM,4v4 NO T64 MWII VARIANT,$7,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,9,Best of 3,$176
+"February 18, 2023",8:56 PM,1v1 $20 GTD CONSOLE SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 3,$20
+"February 18, 2023",8:28 PM,2v2 $50 GTD AR/SMG SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 18, 2023",8:28 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 18, 2023",8:50 AM,1v1 *SCAR ONLY* 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,1,Best of 1,$9
+"February 18, 2023",7:50 AM,Switch winners,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$230
+"February 18, 2023",7:25 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$6
+"February 18, 2023",1:26 AM,1v1 $50 GTD *NO 2023 WINNERS* KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$50
+"February 17, 2023",11:51 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 17, 2023",9:20 PM,2v2 1ND *VAZNEV ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$14
+"February 17, 2023",8:30 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$100
+"February 17, 2023",7:15 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$10
+"February 17, 2023",8:25 AM,2v2 $40 GTD 1ND *VAZNEV ONLY* SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$20
+"February 17, 2023",8:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$10
+"February 17, 2023",6:28 AM,2v2 $50 GTD 1ND AR/SMG SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$50
+"February 17, 2023",6:20 AM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$24
+"February 17, 2023",3:52 AM,4v4 *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 1,$8
+"February 17, 2023",3:25 AM,2v2 $60 GTD SND,$7.5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$60
+"February 17, 2023",3:00 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$100
+"February 17, 2023",2:00 AM,4v4 $400 PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,13,Best of 3,$400
+"February 17, 2023",1:52 AM,2v2 $32 GTD CONSOLE SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 3,$32
+"February 16, 2023",11:56 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 16, 2023",10:56 PM,3v3 $60 GTD SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 3,$60
+"February 16, 2023",10:25 PM,2v2 $24 GTD CONSOLE 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,1,Best of 1,$24
+"February 16, 2023",9:56 PM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$50
+"February 16, 2023",9:30 PM,4v4 $50 FE HYPED ESPORTS VARIANT,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,3,Best of 3,$48
+"February 16, 2023",8:30 PM,2v2 $50 GTD 1ND *DOME ONLY* SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 16, 2023",5:25 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$15
+"February 16, 2023",9:50 AM,1v1 1ND *SCAR ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 16, 2023",8:15 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7

--- a/codagent/all_data.csv
+++ b/codagent/all_data.csv
@@ -1321,3 +1321,97 @@ Date,Time,Title,Buy-in Per Player,Platforms,Team Size,Tournament Type (Ex: Singl
 "February 1, 2023",2:56 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
 "January 31, 2023",7:53 PM,4v4 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,5,Best of 1,$24
 "February 1, 2023",2:27 AM,3v3 $60 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$60
+"February 10, 2023",6:20 AM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$24
+"February 10, 2023",4:22 AM,2v2 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$22
+"February 10, 2023",3:22 AM,4v4 VARIANT,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,5,Best of 3,$72
+"February 10, 2023",2:56 AM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 10, 2023",2:26 AM,2v2 $60 GTD AR/SMG SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$60
+"February 10, 2023",1:56 AM,1v1 $50 GTD *NO PREVIOUS WINNERS* 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$50
+"February 10, 2023",12:51 AM,4v4 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,6,Best of 1,$16
+"February 10, 2023",12:23 AM,3v3 $60 GTD SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 3,$60
+"February 9, 2023",11:51 PM,3v3 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$27
+"February 9, 2023",11:25 PM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 9, 2023",11:15 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,14,Best of 1,$10
+"February 9, 2023",10:25 PM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$24
+"February 9, 2023",10:23 PM,2v2 $50 GTD SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 9, 2023",10:00 PM,2v2 $20 FE 1ND KILL RACE,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,11,Best of 1,$20
+"February 9, 2023",9:30 PM,1v1 $50 GTD NOV/AM 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,7,Best of 1,$50
+"February 9, 2023",9:07 PM,2v2 *VAZNEV ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 3,$28
+"February 9, 2023",7:55 PM,2v2 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$22
+"February 9, 2023",8:50 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 9, 2023",8:27 AM,2v2 $40 *VAZNEV ONLY* 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$40
+"February 9, 2023",6:24 AM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 1,$18
+"February 9, 2023",6:23 AM,2v2 $50 GTD 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 9, 2023",5:23 AM,3v3 $90 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$90
+"February 9, 2023",4:23 AM,2v2 AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 3,$34
+"February 9, 2023",3:30 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$100
+"February 9, 2023",3:20 AM,4v4 *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,9,Best of 1,$28
+"February 9, 2023",2:00 AM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 9, 2023",12:55 AM,3v3 $60 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,6,Best of 1,$60
+"February 9, 2023",12:25 AM,4v4 *NO 2023 WINNERS* VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,2,Best of 3,$44
+"February 8, 2023",11:50 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 8, 2023",10:50 PM,1v1 $50 GTD NOV/AM 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,9,Best of 1,$56
+"February 8, 2023",10:20 PM,3v3 *NO SNIPES* SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 3,$27
+"February 8, 2023",10:20 PM,2v2 CONSOLE 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$32
+"February 8, 2023",9:25 PM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 8, 2023",9:15 PM,4v4 $50 FE HYPED ESPORTS SND,$0,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,19,Best of 3,$48
+"February 8, 2023",8:50 PM,1v1 $20 GTD CONSOLE SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 3,$20
+"February 8, 2023",8:35 PM,2v2 $50 GTD AR/SMG SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$50
+"February 8, 2023",7:02 PM,2v2 *VAZNEV ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$18
+"February 8, 2023",6:05 PM,$1200 GTD WARSZ WEDNESDAY KILL RACE,$20,"['xbox', 'playstation', 'battle.net']",2,double elimination,2v2,38,Best of 3,$1000
+"February 8, 2023",8:50 AM,1v1 1ND *VAZNEV ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 8, 2023",8:20 AM,1v1 CONSOLE 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 1,$7
+"February 8, 2023",8:20 AM,2v2 $40 GTD 1ND AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$50
+"February 8, 2023",7:20 AM,3v3 $45 GTD 1ND *NO SNIPES* SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$45
+"February 8, 2023",6:20 AM,2v2 $50 GTD 1ND *VAZNEV ONLY* SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$50
+"February 8, 2023",3:25 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 8, 2023",3:22 AM,2v2 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$16
+"February 8, 2023",2:53 AM,4v4 VARIANT,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,5,Best of 3,$84
+"February 8, 2023",2:00 AM,2v2 $250 PRESTIGE SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,24,Best of 3,$200
+"February 8, 2023",1:52 AM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 1,$50
+"February 8, 2023",1:27 AM,3v3 $60 GTD 1ND *NO SNIPES* SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$60
+"February 8, 2023",12:22 AM,4v4 *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,12,Best of 1,$32
+"February 7, 2023",11:52 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 7, 2023",10:45 PM,2v2 $20 FE 1ND KILL RACE,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,12,Best of 1,$20
+"February 7, 2023",10:10 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,25,Best of 1,$10
+"February 7, 2023",9:45 PM,1v1 $73 GTD 1ND *NO PREVIOUS WINNERS* KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,12,Best of 1,$73
+"February 7, 2023",8:50 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$9
+"February 7, 2023",8:28 AM,2v2 $40 GTD 1ND AR/SMG SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 1,$40
+"February 7, 2023",5:25 AM,3v3 $90 GTD 1ND SND,$7.5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,6,Best of 1,$90
+"February 7, 2023",4:32 AM,2v2 $50 GTD 1ND SND,$6,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 7, 2023",3:25 AM,3v3 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 1,$33
+"February 7, 2023",3:22 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,8,Best of 1,$100
+"February 7, 2023",2:55 AM,4v4 *NO 2023 WINNERS* VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,8,Best of 3,$152
+"February 7, 2023",2:22 AM,2v2 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$28
+"February 7, 2023",1:52 AM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,9,Best of 1,$50
+"February 7, 2023",1:22 AM,3v3 $72 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,5,Best of 1,$72
+"February 7, 2023",12:20 AM,4v4 HP,$5,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,5,Best of 3,$72
+"February 6, 2023",11:56 PM,2v2 $146 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,12,Best of 1,$146
+"February 6, 2023",11:23 PM,2v2 $50 GTD AR/SMG SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,4,Best of 3,$50
+"February 6, 2023",10:15 PM,2v2 $10 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,27,Best of 1,$10
+"February 6, 2023",9:56 PM,1v1 $50 GTD 1ND *NO PREVIOUS WINNERS* KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,6,Best of 1,$50
+"February 6, 2023",9:55 PM,3v3 *NO SNIPES* SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,4,Best of 3,$42
+"February 6, 2023",8:56 PM,1v1 $10 GTD CONSOLE SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,2,Best of 3,$10
+"February 6, 2023",8:52 PM,2v2 *VAZNEZ ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,2,Best of 3,$14
+"February 6, 2023",8:54 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,3,Best of 1,$9
+"February 6, 2023",8:28 AM,2v2 $40 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$40
+"February 6, 2023",6:30 AM,2v2 $50 GTD 1ND *FORTRESS ONLY* SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 6, 2023",5:20 AM,3v3 $75 GTD 1ND SND,$7,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$75
+"February 6, 2023",4:25 AM,2v2 1ND *VAZNEZ ONLY* SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$38
+"February 6, 2023",3:26 AM,3v3 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,2,Best of 1,$24
+"February 6, 2023",2:52 AM,4v4 *NO 2023 WINNERS* VARIANT,$6,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,11,Best of 3,$220
+"February 6, 2023",2:26 AM,2v2 $100 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,7,Best of 1,$100
+"February 6, 2023",2:00 AM,2v2 $60 GTD CONSOLE SND,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 3,$60
+"February 6, 2023",1:22 AM,3v3 *DOLLAR ENTRY* 1ND SND,$1,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$12
+"February 5, 2023",11:30 PM,2v2 $100 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,6,Best of 1,$100
+"February 5, 2023",10:56 PM,4v4 DOUBLE ELIM VARIANT,$5,"['xbox', 'playstation', 'battle.net']",4,double elimination,4v4,2,Best of 3,$44
+"February 5, 2023",9:56 PM,1v1 $50 GTD 1ND KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$50
+"February 5, 2023",8:30 PM,1v1 $20 GTD CONSOLE SND,$5,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,4,Best of 3,$20
+"February 5, 2023",8:10 PM,3v3 $15 FE 1ND SND,$0,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,10,Best of 1,$15
+"February 5, 2023",7:55 PM,2v2 AR/SMG SND,$4,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,8,Best of 3,$44
+"February 5, 2023",8:50 AM,1v1 *SCAR ONLY* 1ND SND,$4,"['xbox', 'playstation', 'battle.net']",1,single elimination,1v1,5,Best of 1,$14
+"February 5, 2023",8:33 AM,2v2 $40 GTD 1ND SND,$5,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$40
+"February 5, 2023",7:20 AM,3v3 1ND SND *NO SNIPES* SND,$4,"['xbox', 'playstation', 'battle.net']",3,single elimination,3v3,3,Best of 1,$33
+"February 5, 2023",4:30 AM,2v2 $50 GTD 1ND *VAZNEZ ONLY* SND,$7,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,3,Best of 1,$50
+"February 5, 2023",3:00 AM,2v2 $150 GTD 1ND NOV/AM KILL RACE,$8,"['xbox', 'playstation', 'battle.net']",2,single elimination,2v2,5,Best of 1,$150
+"February 5, 2023",2:53 AM,4v4 *NO ABEZYS* *DOLLAR ENTRY* 1ND HP,$1,"['xbox', 'playstation', 'battle.net']",4,single elimination,4v4,9,Best of 1,$28

--- a/codagent/web_scrapper.py
+++ b/codagent/web_scrapper.py
@@ -42,10 +42,15 @@ def get_tournament_info(driver, URL):
     time = date_time_list[3] + " " + date_time_list[4]
     
     # Tourney title
-    title_res = soup.find_all('span', {'class': 'font-semibold text-2xl lg:text-3xl text-white'})
+    title_res = soup.find_all('span', {'class': 'font-semibold text-2xl lg:text-3xl max-w-[420px] break-words text-white'})
     if len(title_res) < 1:
-        title_res = soup.find_all('span', {'class': 'font-semibold text-2xl lg:text-3xl text-gold'})
-    title = title_res[0].text.strip()
+        title_res = soup.find_all('span', {'class': 'font-semibold text-2xl lg:text-3xl max-w-[420px] break-words text-gold'})
+        if len(title_res) < 1:
+            title = 'title error'
+        else: 
+            title = title_res[0].text.strip()
+    else:
+        title = title_res[0].text.strip()
     
     # Per person
     per_person_res = soup.find_all('span', {'class': 'font-semibold text-white'})


### PR DESCRIPTION
There was a bug where the HTML code on our website had tourney titles under a different class type.  Therefore, our mining code threw an error when running.  I fixed this by updating our mining script to look for the new class type.  I also added proper error handling for the future, where if there is an error when mining for a tourney title, the code will return "title error" and proceed to continue with the mining.